### PR TITLE
Solves circular import error

### DIFF
--- a/src/model/Backbone.py
+++ b/src/model/Backbone.py
@@ -43,20 +43,6 @@ def get_channels(backbone_name):
         return [16, 24, 32, 96, 1280]
     elif 'swin_T' in backbone_name:
         return [int(96 * 2 ** i) for i in range(4)]
-
-class Backbone(nn.Module):
-    def __init__(self, layer_list):
-        super(Backbone, self).__init__()
-        self.layers = nn.ModuleList(layer_list)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        f0 = self.layers[0](x)
-        f1 = self.layers[1](f0)
-        f2 = self.layers[2](f1)
-        f3 = self.layers[3](f2)
-        f4 = self.layers[4](f3)
-        return (f0, f1, f2, f3, f4)
-
 class MTF(nn.Module):
     def __init__(self, channel, mode='iade', kernel_size=1):
         super(MTF, self).__init__()

--- a/src/model/backbone_base.py
+++ b/src/model/backbone_base.py
@@ -1,0 +1,16 @@
+import torch
+from torch import nn
+
+
+class Backbone(nn.Module):
+    def __init__(self, layer_list):
+        super(Backbone, self).__init__()
+        self.layers = nn.ModuleList(layer_list)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        f0 = self.layers[0](x)
+        f1 = self.layers[1](f0)
+        f2 = self.layers[2](f1)
+        f3 = self.layers[3](f2)
+        f4 = self.layers[4](f3)
+        return (f0, f1, f2, f3, f4)

--- a/src/model/resnet.py
+++ b/src/model/resnet.py
@@ -3,7 +3,7 @@ import torchvision
 import torch.nn as nn
 from torchvision.models import resnet 
 
-from model.Backbone import Backbone
+from model.backbone_base import Backbone
 
 
 class ResNet(Backbone):

--- a/src/model/vgg.py
+++ b/src/model/vgg.py
@@ -2,7 +2,7 @@ import torch
 import torchvision
 import torch.nn as nn
 
-from model.Backbone import Backbone
+from model.backbone_base import Backbone
 
 
 class VGG(Backbone):


### PR DESCRIPTION
Hi, congrats for your paper! I think that your approach is very interesting and simple, good work. I was trying to reproduce your results and I got the following minor bug. 

# Bug

When trying to run the src/train.py script (with the TSUNAMI dataset), I get the following error:

```
Traceback (most recent call last):
  File "train.py", line 15, in <module>
    from model import model_dict
  File "/app/src/C-3PO/src/model/__init__.py", line 9, in <module>
    from model.FCN import resnet18_mtf_msf_fcn, biresnet18_mtf_msf_fcn, resnet18_msf_fcn
  File "/app/src/C-3PO/src/model/FCN.py", line 11, in <module>
    from model.Backbone import unibackbone_fpn, backbone_mtf_msf, bibackbone_mtf_msf, bibackbone_mtf_msf
  File "/app/src/C-3PO/src/model/Backbone.py", line 13, in <module>
    from model.resnet import ResNet
  File "/app/src/C-3PO/src/model/resnet.py", line 6, in <module>
    from model.Backbone import Backbone
ImportError: cannot import name 'Backbone' from partially initialized module 'model.Backbone' (most likely due to a circular import) (/app/src/C-3PO/src/model/Backbone.py)
```

# Fix

This PR moves the Backbone class definition to a new backbone_base module in order to avoid the circular import error.

This happens when model.resnet and model.vgg modules try to import the Backbone class from model.Backbone, since model.Backbone also tries to import from model.resnet and model.vgg, it creates a circular import problem. 

Since the Backbone class is not used in other parts of the model.Backbone module, it can be moved to a new  module (model.backbone_base) that does not import anything from model.resnet and model.vgg. Thus, by making model.resnet and model.vgg import from model.backbone_base, we solve the circular import problem.